### PR TITLE
Implemented support for Async publish/subscribe.

### DIFF
--- a/Easy.MessageHub.Tests.Unit/MessageHubTests.cs
+++ b/Easy.MessageHub.Tests.Unit/MessageHubTests.cs
@@ -1,4 +1,6 @@
-﻿namespace Easy.MessageHub.Tests.Unit
+﻿using System.Threading.Tasks;
+
+namespace Easy.MessageHub.Tests.Unit
 {
     using System;
     using System.Collections.Concurrent;
@@ -508,6 +510,27 @@
             hub2Messages.ShouldBe(new[] { "B", "C", "D" });
 
             hub2.Dispose();
+        }
+
+        [Test]
+        public async Task When_publishing_using_async()
+        {
+            var hub = new MessageHub();
+
+            var queue = new ConcurrentQueue<string>();
+
+            hub.Subscribe<string>(async msg =>
+            {
+                await Task.Delay(1);
+                queue.Enqueue(msg);
+            });
+
+            await hub.PublishAsync("A");
+
+            queue.Count.ShouldBe(1);
+
+            queue.TryDequeue(out var receivedMsg).ShouldBeTrue();
+            receivedMsg.ShouldBe("A");
         }
     }
 }

--- a/Easy.MessageHub/IMessageHub.cs
+++ b/Easy.MessageHub/IMessageHub.cs
@@ -1,6 +1,7 @@
 ﻿namespace Easy.MessageHub
 {
     using System;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// An implementation of the <c>Event Aggregator</c> pattern.
@@ -28,6 +29,12 @@
         /// </summary>
         /// <param name="message">The message to published</param>
         void Publish<T>(T message);
+
+        /// <summary>
+        /// Publishes the <paramref name="message"/> on the <see cref="IMessageHub"/>.
+        /// </summary>
+        /// <param name="message">The message to published</param>
+        Task PublishAsync<T>(T message);
 
         /// <summary>
         /// Subscribes a callback against the <see cref="IMessageHub"/> for a specific type of message.

--- a/Easy.MessageHub/IMessageHub.cs
+++ b/Easy.MessageHub/IMessageHub.cs
@@ -48,6 +48,14 @@
         /// Subscribes a callback against the <see cref="MessageHub"/> for a specific type of message.
         /// </summary>
         /// <typeparam name="T">The type of message to subscribe to</typeparam>
+        /// <param name="func">The async callback to be invoked once the message is published on the <see cref="MessageHub"/></param>
+        /// <returns>The token representing the subscription</returns>
+        Guid Subscribe<T>(Func<T, Task> func);
+
+        /// <summary>
+        /// Subscribes a callback against the <see cref="MessageHub"/> for a specific type of message.
+        /// </summary>
+        /// <typeparam name="T">The type of message to subscribe to</typeparam>
         /// <param name="action">The callback to be invoked once the message is published on the <see cref="MessageHub"/></param>
         /// <param name="throttleBy">The <see cref="TimeSpan"/> specifying the rate at which subscription is throttled</param>
         /// <returns>The token representing the subscription</returns>

--- a/Easy.MessageHub/Subscription.cs
+++ b/Easy.MessageHub/Subscription.cs
@@ -1,3 +1,5 @@
+using System.Threading.Tasks;
+
 namespace Easy.MessageHub
 {
     using System;
@@ -22,6 +24,13 @@ namespace Easy.MessageHub
             if (!CanHandle()) { return; }
 
             ((Action<T>)Handler)(message);
+        }
+
+        internal async Task HandleAsync<T>(T message)
+        {
+            if (!CanHandle()) { return; }
+
+            await ((Func<T, Task>)Handler)(message);
         }
 
         private bool CanHandle()

--- a/Easy.MessageHub/Subscriptions.cs
+++ b/Easy.MessageHub/Subscriptions.cs
@@ -5,6 +5,7 @@ namespace Easy.MessageHub
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using System.Threading;
+    using System.Threading.Tasks;
 
     [SuppressMessage("ReSharper", "ForCanBeConvertedToForeach")]
     internal class Subscriptions
@@ -20,7 +21,11 @@ namespace Easy.MessageHub
 
         private bool _disposed;
 
-        internal Guid Register<T>(TimeSpan throttleBy, Action<T> action)
+        internal Guid Register<T>(TimeSpan throttleBy, Action<T> action) => Register<T>(throttleBy, (object)action);
+
+        internal Guid Register<T>(TimeSpan throttleBy, Func<T, Task> func) => Register<T>(throttleBy, (object)func);
+
+        internal Guid Register<T>(TimeSpan throttleBy, object action)
         {
             var type = typeof(T);
             var key = Guid.NewGuid();
@@ -31,7 +36,7 @@ namespace Easy.MessageHub
                 AllSubscriptions.Add(subscription);
                 _subscriptionsChangeCounter++;
             }
-            
+
             return key;
         }
 


### PR DESCRIPTION
Hi,

I know there has been discussions before related to an async version, so I will try again. It might be that I have misunderstood something, so feel free to enlighten me:-)

I have tried to adjust your implementation to also support an async version.

My use-case is as follows:

I will publish a message which will be handled by several components. Each of these will have some non cpu bound actions, e.g. accessing Azure blob storage and Redis Cache using async methods.

I need to know that each of the subscribers have completed their work before continuing.

---------------------------
usage:

           hub.Subscribe<string>(async msg =>
            {
                await  ....some async opertion.
            });

           await hub.Publish("some message")
-------------------------------

Many txh:-)
Rune

